### PR TITLE
Read width / height of JPEG alternatively from SOF2 marker and enable reading exif headers.

### DIFF
--- a/lib/exif.js
+++ b/lib/exif.js
@@ -578,7 +578,7 @@ var EXIF = exports;
 	EXIF.readFromBinaryFile = function (oFile) {
 		return findEXIFinJPEG(oFile);
 	};
-
+/*
 	function loadAllImages() {
 		var aImages = document.getElementsByTagName("img");
 		for (var i = 0; i < aImages.length; i++) {
@@ -597,6 +597,6 @@ var EXIF = exports;
 	}
 
 	addEvent(window, "load", loadAllImages);
-
+*/
 })();
 

--- a/main.js
+++ b/main.js
@@ -12,7 +12,7 @@
  */
 var ImageInfo = exports
 	, fs = require('fs')
-//	, EXIF = require('./lib/exif')
+	, EXIF = require('./lib/exif')
 	;
 
 /**

--- a/main.js
+++ b/main.js
@@ -161,7 +161,7 @@ function readJPEGInfo(data) {
 	while (offset < len) {
 		var marker = data.getShortAt(offset, true);
 		offset += 2;
-		if (marker == 0xFFC0) {
+		if (marker == 0xFFC0 || marker == 0xFFC2) {
 			h = data.getShortAt(offset + 3, true);
 			w = data.getShortAt(offset + 5, true);
 			comps = data.getByteAt(offset + 7, true);

--- a/test/crafity.imageinfo.test.js
+++ b/test/crafity.imageinfo.test.js
@@ -63,7 +63,9 @@ var tests = {
 //			console.log("data.toString()", data.toString());
 
 			assert.isDefined(data, "Expected data to be defined");
-			assert.areEqual(data.format.toUpperCase(), "png".toUpperCase(), "Expected PNG format!");
+			assert.areEqual("png".toUpperCase(), data.format.toUpperCase(), "Expected PNG format!");
+			assert.areEqual(398, data.width, "Expected width 320px !");
+			assert.areEqual(179, data.height, "Expected height 320px !");
 		});
 	},
 
@@ -76,7 +78,9 @@ var tests = {
 //			console.log("data.toString()", data.toString());
 
 			assert.isDefined(data, "Expected data to be defined");
-			assert.areEqual(data.format.toUpperCase(), "jpeg".toUpperCase(), "Expected PNG format!");
+			assert.areEqual("jpeg".toUpperCase(), data.format.toUpperCase(), "Expected PNG format!");
+			assert.areEqual(320, data.width, "Expected width 320px !");
+			assert.areEqual(320, data.height, "Expected height 320px !");
 		});
 	}
 


### PR DESCRIPTION
Most of JPEGs does not have SOF0 marker anymore (like the one in test data). Added support for allowing dimensions to be read from SOF2 marker. Also enabled reading exif headers.
